### PR TITLE
Fixed absent license_file in galaxy.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and [human-readable changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Refactoring of ansible role remote_desktop.
 
+### Fixed
+
+- Fixed absent license_file in galaxy.yml.
+
 ## 0.0.4
 
 ### Added

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,6 @@ authors:
 description: 'Ansible Collection for Windows functions.'
 license:
   - MIT
-license_file: 'LICENSE'
 tags:
   - windows
 dependencies: {}


### PR DESCRIPTION
### Fixed

- Fixed absent license_file in galaxy.yml.