### PR TITLE
Fix error "Could not find local group"

### DIFF
--- a/roles/remote_desktop/tasks/main.yml
+++ b/roles/remote_desktop/tasks/main.yml
@@ -69,6 +69,7 @@
     name: '{{ remote_desktop_group }}'
     members: '{{ remote_desktop_members }}'
     state: present
+  when: remote_desktop_members is defined and remote_desktop_members | length > 0
 
 # https://www.winfaq.de/faq_html/Content/tip1000/onlinefaq.php?h=tip1368.htm
 - name: Disable Shutdown Butten from Windows Start


### PR DESCRIPTION
Full error message was:
```
TASK [remote_desktop : Add User or Group to Login group for Remote Desktop] ****
fatal: [vagrant-win2012r2]: FAILED! => {"added": [], "changed": false, "msg": "Could not find local group Remotedesktopbenutzer", "name": "Remotedesktopbenutzer"}
```