### PR TITLE
Defender: do nothing for Windows <= 2012

### DIFF
--- a/roles/defender/tasks/main.yml
+++ b/roles/defender/tasks/main.yml
@@ -3,3 +3,4 @@
 
 - name: 'Disable or Enable Defender'
   win_shell: 'Set-MpPreference -DisableRealtimeMonitoring ${{ defender_disable }}'
+  when: ansible_distribution_major_version is version('6', '>')


### PR DESCRIPTION
With this change, playbooks compatible with both Windows 2012 and 2016+ can use sbaerlocher.windows.defender since the role do nothing for Windows 2012.

Before, an error was raised for Windows 2012:
```
The term 'Set-MpPreference' is not recognized as the name of a cmdlet, function, script file, or operable program. 
```

